### PR TITLE
fix: remove borked terminal and exclude files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,6 +12,9 @@
     ],
     "dockerFile": "Dockerfile",
     "settings": {
-        "terminal.integrated.shell.linux": "/usr/bin/zsh"
+        "files.exclude": {
+            "**/CODE_OF_CONDUCT.md": true,
+            "**/LICENSE": true
+        }
     }
 }


### PR DESCRIPTION
Currently if you try to open a terminal the terminal will fail because it was being started by the LOC removed in this PR. Additionally, this PR removes two files from loading into the environment that are useful for maintainers but not useful for users.