### PR TITLE
feat(extensions): add GitHub Actions extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,6 +2,7 @@
     "name": "Codespaces Go Template Repository",
     "extensions": [
         "coenraads.bracket-pair-colorizer-2",
+        "cschleiden.vscode-github-actions",
         "eamodio.gitlens",
         "github.vscode-pull-request-github",
         "ms-azuretools.vscode-docker",


### PR DESCRIPTION
Adds the GitHub Actions extension. This extension is progressing quite nicely, so wanted to get it in now. Feel free to close out the PR if it doesn't make sense for the Go ecosystem.